### PR TITLE
Create relationShip with Animals And Responsible #23

### DIFF
--- a/src/animal/animal.service.ts
+++ b/src/animal/animal.service.ts
@@ -20,7 +20,7 @@ export class AnimalService {
 
   findAll() {
     return this.animalRepository.find({
-      relations: ['medias'],
+      relations: ['medias', 'responsible'],
     });
   }
 
@@ -29,14 +29,14 @@ export class AnimalService {
       where: {
         id,
       },
-      relations: ['medias'],
+      relations: ['medias', 'responsible'],
     });
   }
 
   find(animal: AnimalGetPatchDto) {
     return this.animalRepository.find({
       where: animal,
-      relations: ['medias'],
+      relations: ['medias', 'responsible'],
     });
   }
 

--- a/src/animal/dto/animal.dto.ts
+++ b/src/animal/dto/animal.dto.ts
@@ -1,4 +1,5 @@
 import { Media } from '../../media/entities/media.entity';
+import { ResponsibleDto } from '../../responsible/dto/responsible.dto';
 
 export class AnimalDto {
   name: string;
@@ -8,6 +9,6 @@ export class AnimalDto {
   specie_id: number;
   color_id: number;
   status: string;
-  responsible_id: number; /** Alterado para relacionamento OneToOne */
+  responsible: ResponsibleDto; /** Alterado para relacionamento OneToOne */
   medias?: Media[];
 }

--- a/src/animal/entities/animal.entity.ts
+++ b/src/animal/entities/animal.entity.ts
@@ -3,8 +3,8 @@ import {
   CreateDateColumn,
   Entity,
   PrimaryGeneratedColumn,
-  OneToOne,
   OneToMany,
+  OneToOne,
 } from 'typeorm';
 import { Media } from '../../media/entities/media.entity';
 import { Responsible } from '../../responsible/entities/responsible.entity';
@@ -29,8 +29,10 @@ export class Animal {
   @Column()
   color_id: number;
 
-  @OneToOne(() => Responsible, (responsible) => responsible.id)
-  responsible_id: number;
+  @OneToOne(() => Responsible, (responsible) => responsible.animal, {
+    cascade: ['insert'],
+  })
+  responsible?: Responsible;
 
   @Column({ nullable: true })
   age?: number;

--- a/src/responsible/dto/responsible.dto.ts
+++ b/src/responsible/dto/responsible.dto.ts
@@ -2,7 +2,4 @@ export class ResponsibleDto {
   name: string;
   cellphone: string;
   email?: string;
-  createdAt?: Date;
-  updatedAt?: Date;
-  deletedAt?: Date;
 }

--- a/src/responsible/entities/responsible.entity.ts
+++ b/src/responsible/entities/responsible.entity.ts
@@ -2,8 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { Animal } from '../../animal/entities/animal.entity';
 
 @Entity()
 export class Responsible {
@@ -18,6 +21,10 @@ export class Responsible {
 
   @Column({ nullable: true })
   email?: string;
+
+  @OneToOne(() => Animal, (animal) => animal.responsible)
+  @JoinColumn()
+  animal?: Animal;
 
   @CreateDateColumn({
     type: 'timestamp',


### PR DESCRIPTION
# Adicionando retorno de responsável na busca por animals.

## Issue #23


### Alterações Realizadas:
* Adicionado criação do ` responsible` dentro do endpoint de criação de `animals`;
* Corrigido relacionamento entre animals e responsible;

## Como Testar
* Realizar busca de animais e validar se a chave `responsible` retorna quando ele está presente;
* Realizar cadastro de um `animal` com a chave `responsible` presente;
### Payload Exemplo:
```bash
curl --location 'http://localhost:3000/api/animals' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "Bob",
    "description": "Um animalzinho feliz.",
    "size_id": 1,
    "specie_id": 1,
    "color_id": 1,
    "age": 9,
    "responsible": {
      "name": "Sr. Responsavel",
      "cellphone": "5511999999999",
      "email": "sr_responsavel@email.com"
    },
    "medias": [
        {
            "mediaType": "image/jpg",
            "url": "https://gcloud.com/teste/image.jpg"
        },
        {
            "mediaType": "image/jpg",
            "url": "https://gcloud.com/teste/image.png"
        }
    ]
}'
```


That's All Folks !